### PR TITLE
Bug fix

### DIFF
--- a/.github/workflows/ghcr-docker-image.yml
+++ b/.github/workflows/ghcr-docker-image.yml
@@ -2,6 +2,9 @@ name: Build and Push to GHCR
 
 # 允许手动触发工作流，也可以配置当推送到主干或开发分支时自动触发
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/ghcr-docker-image.yml
+++ b/.github/workflows/ghcr-docker-image.yml
@@ -11,8 +11,6 @@ on:
         description: '输入要构建的镜像版本号 (例如: 1.0.0)，留空则自动从 package.json 读取'
         required: false
         default: ''
-  push:
-    branches: [ "main", "master", "dev" ]
 
 env:
   REGISTRY: ghcr.io

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -385,36 +385,27 @@ class TaskService {
                         logTaskEvent(`[AI重命名] 使用提取的 TMDB ID ${extractedTmdbId} 直接查询详情...`);
                         const tmdbService = new TMDBService();
 
-                        // 根据用户指定的类型查询，未指定时先尝试 TV 再尝试 Movie
+                        // 使用启发式推断结果决定查询顺序，auto-detect 的 videoType 作为回退
                         let detail = null;
-                        if (taskDto?.videoType === 'movie') {
+                        const searchType = inferredType || taskDto?.videoType || 'tv';
+                        if (searchType === 'movie') {
                             detail = await tmdbService.getMovieDetails(extractedTmdbId);
-                            tmdbType = 'movie';
-                        } else if (taskDto?.videoType === 'tv') {
-                            detail = await tmdbService.getTVDetails(extractedTmdbId);
-                            tmdbType = 'tv';
-                        } else {
-                            // 未指定类型，使用启发式推断结果决定搜索顺序
-                            const searchType = inferredType || 'tv';
-                            if (searchType === 'movie') {
-                                detail = await tmdbService.getMovieDetails(extractedTmdbId);
-                                if (detail && detail.title) {
-                                    tmdbType = 'movie';
-                                } else {
-                                    detail = await tmdbService.getTVDetails(extractedTmdbId);
-                                    if (detail && detail.title) {
-                                        tmdbType = 'tv';
-                                    }
-                                }
+                            if (detail && detail.title) {
+                                tmdbType = 'movie';
                             } else {
                                 detail = await tmdbService.getTVDetails(extractedTmdbId);
                                 if (detail && detail.title) {
                                     tmdbType = 'tv';
-                                } else {
-                                    detail = await tmdbService.getMovieDetails(extractedTmdbId);
-                                    if (detail && detail.title) {
-                                        tmdbType = 'movie';
-                                    }
+                                }
+                            }
+                        } else {
+                            detail = await tmdbService.getTVDetails(extractedTmdbId);
+                            if (detail && detail.title) {
+                                tmdbType = 'tv';
+                            } else {
+                                detail = await tmdbService.getMovieDetails(extractedTmdbId);
+                                if (detail && detail.title) {
+                                    tmdbType = 'movie';
                                 }
                             }
                         }

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -322,8 +322,8 @@ class TaskService {
 
             // ====== 启发式判断视频类型（在 TMDB 搜索前分析资源特征） ======
             let inferredType = null; // 启发式推断的类型，优先级低于用户指定
+            // 1. 根据保存路径中的关键字判断（仅当用户未指定类型时）
             if (!taskDto?.videoType) {
-                // 1. 根据保存路径中的关键字判断
                 const savePath = taskDto?.realFolderName || '';
                 const moviePathKeywords = ['/电影/', '/Movies/', '/Movie/', '/movie/', '/影片/'];
                 const tvPathKeywords = ['/电视剧/', '/TV/', '/Tv/', '/tv/', '/剧集/', '/动漫/', '/番剧/'];
@@ -334,31 +334,30 @@ class TaskService {
                     inferredType = 'tv';
                     logTaskEvent(`[AI重命名] 启发式判断：保存路径含电视剧关键字 -> 推断为电视剧`);
                 }
+            }
 
-                // 2. 根据文件数量判断（单文件更可能是电影）
-                if (!inferredType && files && files.length > 0) {
-                    const mediaFiles = files.filter(f => !f.isFolder);
-                    if (mediaFiles.length === 1) {
-                        inferredType = 'movie';
-                        logTaskEvent(`[AI重命名] 启发式判断：仅1个媒体文件 -> 推断为电影`);
-                    }
+            // 2. 根据文件数量判断（单文件更可能是电影）
+            if (!inferredType && files && files.length > 0) {
+                const mediaFiles = files.filter(f => !f.isFolder);
+                if (mediaFiles.length === 1) {
+                    inferredType = 'movie';
+                    logTaskEvent(`[AI重命名] 启发式判断：仅1个媒体文件 -> 推断为电影`);
                 }
+            }
 
-                // 3. 根据文件名中的季集信息判断（有季集标识则是电视剧）
-                if (!inferredType && files && files.length > 0) {
-                    const hasEpisodePattern = files.some(f =>
-                        /S\d+[-_ ]*E\d+|第\s*\d+\s*[集话]|EP?\d+/i.test(f.name || '')
-                    );
-                    if (hasEpisodePattern) {
-                        inferredType = 'tv';
-                        logTaskEvent(`[AI重命名] 启发式判断：文件名含季集标识 -> 推断为电视剧`);
-                    }
+            // 3. 根据文件名中的季集信息判断（有季集标识则是电视剧）
+            if (!inferredType && files && files.length > 0) {
+                const hasEpisodePattern = files.some(f =>
+                    /S\d+[-_ ]*E\d+|第\s*\d+\s*[集话]|EP?\d+/i.test(f.name || '')
+                );
+                if (hasEpisodePattern) {
+                    inferredType = 'tv';
+                    logTaskEvent(`[AI重命名] 启发式判断：文件名含季集标识 -> 推断为电视剧`);
                 }
+            }
 
-                // 4. 多文件且无季集信息，可能是电影合集，仍优先搜电视剧（安全回退）
-                if (inferredType) {
-                    logTaskEvent(`[AI重命名] 启发式判断最终结果: ${inferredType === 'movie' ? '电影' : '电视剧'}`);
-                }
+            if (inferredType) {
+                logTaskEvent(`[AI重命名] 启发式判断最终结果: ${inferredType === 'movie' ? '电影' : '电视剧'}`);
             }
 
             try {

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -206,7 +206,8 @@ class TaskService {
 
         // 3. 移除季集信息 (S01E01, S01, E01, 第1集, 第1季 等)
         name = name.replace(/\.S\d+[-_ ]*E\d+/gi, '.');  // S01E01
-        name = name.replace(/\.S\d+/gi, '.');            // S01
+        name = name.replace(/\.S\d+.*/i, '');            // S01 → 截断其后所有内容
+        name = name.replace(/\s+S\d+\s*.*/i, '');        // S01 (空格版) → 截断
         name = name.replace(/\.E[P]?\d+/gi, '.');        // E01, EP01
         name = name.replace(/\.第\s*\d+\s*[集季话]/gi, '.'); // 第1集, 第1季, 第1话
 

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -395,14 +395,27 @@ class TaskService {
                             detail = await tmdbService.getTVDetails(extractedTmdbId);
                             tmdbType = 'tv';
                         } else {
-                            // 未指定类型，优先尝试 TV（因为 CAS 资源多为剧集）
-                            detail = await tmdbService.getTVDetails(extractedTmdbId);
-                            if (detail && detail.title) {
-                                tmdbType = 'tv';
-                            } else {
+                            // 未指定类型，使用启发式推断结果决定搜索顺序
+                            const searchType = inferredType || 'tv';
+                            if (searchType === 'movie') {
                                 detail = await tmdbService.getMovieDetails(extractedTmdbId);
                                 if (detail && detail.title) {
                                     tmdbType = 'movie';
+                                } else {
+                                    detail = await tmdbService.getTVDetails(extractedTmdbId);
+                                    if (detail && detail.title) {
+                                        tmdbType = 'tv';
+                                    }
+                                }
+                            } else {
+                                detail = await tmdbService.getTVDetails(extractedTmdbId);
+                                if (detail && detail.title) {
+                                    tmdbType = 'tv';
+                                } else {
+                                    detail = await tmdbService.getMovieDetails(extractedTmdbId);
+                                    if (detail && detail.title) {
+                                        tmdbType = 'movie';
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## 修复的两个 Bug

### Bug 1: TMDB ID 查询忽略文件类型推断

**问题**: 当 `{tmdb-xxx}` 存在于资源名中但用户未指定 `videoType` 时，
`_analyzeResourceInfo` 硬编码优先查询 TV API。如果该 TMDB ID 同时存在
TV 条目，即使资源是电影（保存路径含 "/电影/"）也会被错误识别为电视剧，
导致重命名为 `xxx.S01ENaN.cas`。

**修复**: `src/services/task.js` 第 397-421 行，将硬编码的 TV-first 改为
使用已计算好的 `inferredType`（三段启发式：保存路径关键字 → 文件数量 →
文件名季集标识）决定查询顺序，与同方法内 fallback 搜索逻辑保持一致。

**影响范围**: 仅当 `videoType` 未指定且 `inferredType === 'movie'` 时行为
变化，其他场景与原逻辑完全一致。

Ref: `_analyzeResourceInfo` method

### Bug 2: _extractCleanTitle 未截断 Sxx 后技术参数

**问题**: `.Sxx` 后的流媒体来源标识（`NF`、`AMZN`、`FriDay`、`Hami` 等）、
连字符分隔的发布组名（`-HiveWeb`）、中文标签（`臻彩`、`内嵌简中`）、
`H.265`、`DDP` 等技术参数不在黑名单中，频繁导致 TMDB fallback 搜索
因噪音匹配失败。

**修复**: `src/services/task.js` 第 209-210 行，将 Sxx 匹配由替换为 `.`
改为截断其后所有内容（`/\.S\d+.*/`），并新增空格分隔 Sxx 的截断逻辑
（`/\s+S\d+\s*.*/`）。Sxx 后的所有技术参数一次性清除，不再依赖
黑名单维护。

**影响范围**: 无 Sxx 的文件（纯电影）不受影响；SxxExx 格式由上游
第 208 行先处理，截断不触发。