### PR TITLE
Bug Fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const TelegramBotManager = require('./utils/TelegramBotManager');
 const fs = require('fs').promises;
 const path = require('path');
 const { setupCloudSaverRoutes, clearCloudSaverToken } = require('./sdk/cloudsaver');
-const { Like, Not, IsNull, In, Or } = require('typeorm');
+const { Like, Not, IsNull, In, Or, MoreThan } = require('typeorm');
 const cors = require('cors'); 
 const { EmbyService } = require('./services/emby');
 const { StrmService } = require('./services/strm');
@@ -340,13 +340,29 @@ AppDataSource.initialize().then(async () => {
     // 任务相关API
     app.get('/api/tasks', async (req, res) => {
         const { status, search } = req.query;
-        let whereClause = { }; // 用于构建最终的 where 条件
+        let whereClause = { };
 
         // 基础条件（AND）
         if (status && status !== 'all') {
-            whereClause.status = status;
+            if (status === 'processing') {
+                // 追剧中 = processing 或 pending但有内容
+                whereClause = [
+                    { status: 'processing', enableSystemProxy: Or(IsNull(), false) },
+                    { status: 'pending', currentEpisodes: MoreThan(0), enableSystemProxy: Or(IsNull(), false) }
+                ];
+            } else if (status === 'pending') {
+                // 等待中 = pending且无内容
+                whereClause = [
+                    { status: 'pending', currentEpisodes: 0, enableSystemProxy: Or(IsNull(), false) },
+                    { status: 'pending', currentEpisodes: IsNull(), enableSystemProxy: Or(IsNull(), false) }
+                ];
+            } else {
+                whereClause.status = status;
+            }
         }
-        whereClause.enableSystemProxy = Or(IsNull(), false);
+        if (!Array.isArray(whereClause)) {
+            whereClause.enableSystemProxy = Or(IsNull(), false);
+        }
 
         // 添加搜索过滤
         if (search) {
@@ -355,12 +371,21 @@ AppDataSource.initialize().then(async () => {
                 { remark: Like(`%${search}%`) },
                 { account: { username: Like(`%${search}%`) } }
             ];
-            if (Object.keys(whereClause).length > 0) {
+            if (Array.isArray(whereClause)) {
+                // 数组where（OR条件）时，与搜索条件做笛卡尔积
+                const expandedWhere = [];
+                for (const baseCond of whereClause) {
+                    for (const searchCond of searchConditions) {
+                        expandedWhere.push({ ...baseCond, ...searchCond });
+                    }
+                }
+                whereClause = expandedWhere;
+            } else if (Object.keys(whereClause).length > 0) {
                 whereClause = searchConditions.map(searchCond => ({
-                    ...whereClause, // 包含基础条件 (如 status)
-                    ...searchCond   // 包含一个搜索条件
+                    ...whereClause,
+                    ...searchCond
                 }));
-            }else{
+            } else {
                 whereClause = searchConditions;
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -631,6 +631,7 @@ AppDataSource.initialize().then(async () => {
                             }
                         }
                         messageUtil.sendMessage(message);
+                        messageUtil.sendWebhookMessage(message);
 
                         // 重命名后触发 Emby 扫库
                         const { EmbyService } = require('./services/emby');
@@ -650,7 +651,7 @@ AppDataSource.initialize().then(async () => {
                     messageUtil.sendMessage(`❌《${task.resourceName}》TMDB绑定后重命名失败: ${e.message}`);
                 }
             };
-            renameTask().catch(() => {}); // 异步执行，不阻塞
+            renameTask().catch(e => logTaskEvent(`[TMDB绑定] 异步重命名失败: ${e.message}`)); // 异步执行，不阻塞
 
             res.json({ success: true, data: task });
         } catch (error) {

--- a/src/services/emby.js
+++ b/src/services/emby.js
@@ -13,7 +13,7 @@ const { Not, IsNull, Like } = require('typeorm');
 // emby接口
 class EmbyService {
     constructor(taskService) {
-        this.enable = ConfigService.getConfigValue('emby');
+        this.enable = ConfigService.getConfigValue('emby.enable');
         this.embyUrl = ConfigService.getConfigValue('emby.serverUrl');
         this.embyApiKey = ConfigService.getConfigValue('emby.apiKey');
         this.embyPathReplace = ''

--- a/src/services/scheduler.js
+++ b/src/services/scheduler.js
@@ -41,6 +41,38 @@ class SchedulerService {
                 await taskService.clearRecycleBin(enableAutoClearRecycle, enableAutoClearFamilyRecycle);
             })   
         }
+
+        // 4. TV 剧集每日总集数刷新（自动跟踪连载剧集数变动，集数满足时自动完结）
+        this.saveDefaultTaskJob('TV剧集总集数刷新', '0 2 * * *', async () => {
+            const tasks = await taskRepo.find({ where: { videoType: 'tv' } });
+            const { TMDBService } = require('./tmdb');
+            const tmdbService = new TMDBService();
+            for (const task of tasks) {
+                if (task.status === 'completed' || !task.tmdbId) continue;
+                try {
+                    const detail = await tmdbService.getTVDetails(task.tmdbId);
+                    if (!detail?.seasons) continue;
+                    const seasonNum = (() => {
+                        const n = task.shareFolderName || task.resourceName || '';
+                        const m = n.match(/(?:Season|S|第)\s*(\d+)/i);
+                        return m ? parseInt(m[1]) : detail.lastEpisodeToAir?.season_number || null;
+                    })() || Math.max(...detail.seasons.filter(s => s.season_number > 0).map(s => s.season_number), 0);
+                    const seasonData = detail.seasons.find(s => s.season_number === seasonNum);
+                    if (seasonData?.episode_count && seasonData.episode_count !== task.totalEpisodes) {
+                        task.totalEpisodes = seasonData.episode_count;
+                        await taskRepo.save(task);
+                        logTaskEvent(`[TV更新] ${task.resourceName} 总集数更新: ${seasonData.episode_count}`);
+                    }
+                    if (task.totalEpisodes && task.currentEpisodes >= task.totalEpisodes) {
+                        task.status = 'completed';
+                        await taskRepo.save(task);
+                        logTaskEvent(`[TV完结] ${task.resourceName} 已完结（${task.currentEpisodes}/${task.totalEpisodes}）`);
+                    }
+                } catch (e) {
+                    logTaskEvent(`[TV更新] ${task.resourceName} 失败: ${e.message}`);
+                }
+            }
+        });
     }
 
     static saveTaskJob(task, taskService) {

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -336,16 +336,7 @@ class TaskService {
                 }
             }
 
-            // 2. 根据文件数量判断（单文件更可能是电影）
-            if (!inferredType && files && files.length > 0) {
-                const mediaFiles = files.filter(f => !f.isFolder);
-                if (mediaFiles.length === 1) {
-                    inferredType = 'movie';
-                    logTaskEvent(`[AI重命名] 启发式判断：仅1个媒体文件 -> 推断为电影`);
-                }
-            }
-
-            // 3. 根据文件名中的季集信息判断（有季集标识则是电视剧）
+            // 2. 根据文件名中的季集信息判断（有季集标识则是电视剧）
             if (!inferredType && files && files.length > 0) {
                 const hasEpisodePattern = files.some(f =>
                     /S\d+[-_ ]*E\d+|第\s*\d+\s*[集话]|EP?\d+/i.test(f.name || '')
@@ -353,6 +344,15 @@ class TaskService {
                 if (hasEpisodePattern) {
                     inferredType = 'tv';
                     logTaskEvent(`[AI重命名] 启发式判断：文件名含季集标识 -> 推断为电视剧`);
+                }
+            }
+
+            // 3. 根据文件数量判断（单文件更可能是电影）
+            if (!inferredType && files && files.length > 0) {
+                const mediaFiles = files.filter(f => !f.isFolder);
+                if (mediaFiles.length === 1) {
+                    inferredType = 'movie';
+                    logTaskEvent(`[AI重命名] 启发式判断：仅1个媒体文件 -> 推断为电影`);
                 }
             }
 
@@ -978,11 +978,72 @@ class TaskService {
                             } else if (tvDetail?.title) {
                                 task.videoType = 'tv';
                                 task.tmdbTitle = tvDetail.title;
+
+                                // 自动设置当前季总集数
+                                const seasonNum = (() => {
+                                    const n = task.shareFolderName || task.resourceName || '';
+                                    const m = n.match(/(?:Season|S|第)\s*(\d+)/i);
+                                    return m ? parseInt(m[1]) : tvDetail.lastEpisodeToAir?.season_number || null;
+                                })() || Math.max(...(tvDetail.seasons || []).filter(s => s.season_number > 0).map(s => s.season_number), 0);
+                                const s = (tvDetail.seasons || []).find(s => s.season_number === seasonNum);
+                                if (s?.episode_count > 0) {
+                                    task.totalEpisodes = s.episode_count;
+                                    logTaskEvent(`[任务执行] ${tvDetail.title} 第${seasonNum}季: 总集数 ${s.episode_count}`);
+                                }
                             }
                         } catch (e) {
                             logTaskEvent(`[任务执行] TMDB ID ${extractedTmdbId} 类型检测失败: ${e.message}`);
                         }
                     }
+
+                    // ====== 4. 未找到 TMDB ID 时通过标题搜索补全 ======
+                    if (!task.tmdbId && tmdbApiKey && !task.videoType && task.resourceName) {
+                        try {
+                            const baseName = this._extractCleanTitle(task.resourceName);
+                            const year = this._extractYear(task.resourceName);
+                            logTaskEvent(`[任务执行] 未发现 TMDB ID，尝试标题搜索: "${baseName}"`);
+
+                            const savePath = task.realFolderName || '';
+                            let inferredType = 'tv';
+                            if (['/电影/', '/Movies/', '/movie/', '/影片/'].some(k => savePath.includes(k))) {
+                                inferredType = 'movie';
+                            } else if (['/电视剧/', '/TV/', '/tv/', '/剧集/', '/动漫/', '/番剧/',
+                                        '/国产剧/', '/外语剧/', '/更新中/', '/纪录片/'].some(k => savePath.includes(k))) {
+                                inferredType = 'tv';
+                            }
+                            if (!inferredType && /S\d{1,2}[-_ ]*E\d{1,3}|Season\s*\d+|第\s*\d+\s*[季集话]|\d{1,4}x\d{1,3}/i.test(task.resourceName || '')) {
+                                inferredType = 'tv';
+                            }
+
+                            const tmdbService = new TMDBService();
+                            let detail = null;
+                            if (inferredType === 'movie') {
+                                const sr = await tmdbService.searchMovie(baseName, year ? String(year) : '');
+                                if (sr?.id) detail = await tmdbService.getMovieDetails(sr.id);
+                                if (!detail) {
+                                    const sr2 = await tmdbService.searchTV(baseName, year ? String(year) : '');
+                                    if (sr2?.id) detail = await tmdbService.getTVDetails(sr2.id);
+                                }
+                            } else {
+                                const sr = await tmdbService.searchTV(baseName, year ? String(year) : '');
+                                if (sr?.id) detail = await tmdbService.getTVDetails(sr.id);
+                                if (!detail) {
+                                    const sr2 = await tmdbService.searchMovie(baseName, year ? String(year) : '');
+                                    if (sr2?.id) detail = await tmdbService.getMovieDetails(sr2.id);
+                                }
+                            }
+
+                            if (detail?.title) {
+                                task.tmdbId = String(detail.id);
+                                task.videoType = detail.type || inferredType;
+                                task.tmdbTitle = detail.title;
+                                logTaskEvent(`[任务执行] TMDB 标题搜索匹配成功: ${detail.title}（${detail.id}），类型: ${task.videoType}`);
+                            }
+                        } catch (e) {
+                            logTaskEvent(`[任务执行] TMDB 标题搜索失败: ${e.message}`);
+                        }
+                    }
+
                     await this.taskRepo.save(task);
                 }
             }
@@ -1889,6 +1950,14 @@ class TaskService {
                     logTaskEvent(`${task.resourceName} 首次检查完成，已有 ${existingMediaCount} 集`);
                 }
             }
+            // 电影自动完结
+            if (task.videoType === 'movie' && task.status !== 'failed') {
+                task.totalEpisodes = 1;
+                task.currentEpisodes = 1;
+                task.status = 'completed';
+                logTaskEvent(`电影 ${task.resourceName} 已完结，不再占用定时资源`);
+            }
+
             // 检查是否达到总数
             if (task.totalEpisodes && task.currentEpisodes >= task.totalEpisodes) {
                 task.status = 'completed';

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -435,6 +435,20 @@ class TaskService {
                                 tmdbType = 'movie';
                                 if (movieResult.releaseDate) year = parseInt(movieResult.releaseDate.substring(0, 4)) || year;
                                 tmdbParsed = true;
+                                if (taskDto) {
+                                    taskDto.tmdbId = String(movieResult.id);
+                                    taskDto.tmdbTitle = movieResult.title;
+                                    taskDto.videoType = 'movie';
+                                    taskDto.tmdbContent = JSON.stringify(movieResult);
+                                    if (movieResult.type === 'tv' && movieResult.seasons) {
+                                        const n = taskDto.shareFolderName || taskDto.resourceName || '';
+                                        const m = n.match(/(?:Season|S|第)\s*(\d+)/i);
+                                        const seasonNum = (m ? parseInt(m[1]) : null)
+                                            || Math.max(...movieResult.seasons.filter(s => s.season_number > 0).map(s => s.season_number), 0);
+                                        const s = movieResult.seasons.find(s => s.season_number === seasonNum);
+                                        if (s?.episode_count > 0) taskDto.totalEpisodes = s.episode_count;
+                                    }
+                                }
                             }
                         } else if (taskDto?.videoType === 'tv') {
                             const tvResult = await tmdbService.searchTV(baseName, year ? year.toString() : '');
@@ -443,6 +457,20 @@ class TaskService {
                                 tmdbType = 'tv';
                                 if (tvResult.releaseDate) year = parseInt(tvResult.releaseDate.substring(0, 4)) || year;
                                 tmdbParsed = true;
+                                if (taskDto) {
+                                    taskDto.tmdbId = String(tvResult.id);
+                                    taskDto.tmdbTitle = tvResult.title;
+                                    taskDto.videoType = 'tv';
+                                    taskDto.tmdbContent = JSON.stringify(tvResult);
+                                    if (tvResult.seasons) {
+                                        const n = taskDto.shareFolderName || taskDto.resourceName || '';
+                                        const m = n.match(/(?:Season|S|第)\s*(\d+)/i);
+                                        const seasonNum = (m ? parseInt(m[1]) : null)
+                                            || Math.max(...tvResult.seasons.filter(s => s.season_number > 0).map(s => s.season_number), 0);
+                                        const s = tvResult.seasons.find(s => s.season_number === seasonNum);
+                                        if (s?.episode_count > 0) taskDto.totalEpisodes = s.episode_count;
+                                    }
+                                }
                             }
                         } else {
                             // 未指定类型，使用启发式判断结果决定搜索优先级
@@ -457,6 +485,20 @@ class TaskService {
                                 if (primaryResult.releaseDate) year = parseInt(primaryResult.releaseDate.substring(0, 4)) || year;
                                 tmdbParsed = true;
                                 logTaskEvent(`[AI重命名] TMDB ${searchType === 'movie' ? '电影' : '电视剧'}搜索匹配成功: ${tmdbName}`);
+                                if (taskDto) {
+                                    taskDto.tmdbId = String(primaryResult.id);
+                                    taskDto.tmdbTitle = primaryResult.title;
+                                    taskDto.videoType = primaryResult.type || searchType;
+                                    taskDto.tmdbContent = JSON.stringify(primaryResult);
+                                    if ((primaryResult.type || searchType) === 'tv' && primaryResult.seasons) {
+                                        const n = taskDto.shareFolderName || taskDto.resourceName || '';
+                                        const m = n.match(/(?:Season|S|第)\s*(\d+)/i);
+                                        const seasonNum = (m ? parseInt(m[1]) : null)
+                                            || Math.max(...primaryResult.seasons.filter(s => s.season_number > 0).map(s => s.season_number), 0);
+                                        const s = primaryResult.seasons.find(s => s.season_number === seasonNum);
+                                        if (s?.episode_count > 0) taskDto.totalEpisodes = s.episode_count;
+                                    }
+                                }
                             } else {
                                 // 首选类型搜不到，尝试另一种类型
                                 const fallbackType = searchType === 'movie' ? 'tv' : 'movie';
@@ -469,6 +511,20 @@ class TaskService {
                                     if (fallbackResult.releaseDate) year = parseInt(fallbackResult.releaseDate.substring(0, 4)) || year;
                                     tmdbParsed = true;
                                     logTaskEvent(`[AI重命名] 首选类型未匹配，回退${fallbackType === 'movie' ? '电影' : '电视剧'}搜索成功: ${tmdbName}`);
+                                    if (taskDto) {
+                                        taskDto.tmdbId = String(fallbackResult.id);
+                                        taskDto.tmdbTitle = fallbackResult.title;
+                                        taskDto.videoType = fallbackResult.type || fallbackType;
+                                        taskDto.tmdbContent = JSON.stringify(fallbackResult);
+                                        if ((fallbackResult.type || fallbackType) === 'tv' && fallbackResult.seasons) {
+                                            const n = taskDto.shareFolderName || taskDto.resourceName || '';
+                                            const m = n.match(/(?:Season|S|第)\s*(\d+)/i);
+                                            const seasonNum = (m ? parseInt(m[1]) : null)
+                                                || Math.max(...fallbackResult.seasons.filter(s => s.season_number > 0).map(s => s.season_number), 0);
+                                            const s = fallbackResult.seasons.find(s => s.season_number === seasonNum);
+                                            if (s?.episode_count > 0) taskDto.totalEpisodes = s.episode_count;
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -206,7 +206,8 @@ class TaskService {
 
         // 3. 移除季集信息 (S01E01, S01, E01, 第1集, 第1季 等)
         name = name.replace(/\.S\d+[-_ ]*E\d+/gi, '.');  // S01E01
-        name = name.replace(/\.S\d+/gi, '.');            // S01
+        name = name.replace(/\.S\d+.*/i, '');            // S01 → 截断其后所有内容
+        name = name.replace(/\s+S\d+\s*.*/i, '');        // S01 (空格版) → 截断
         name = name.replace(/\.E[P]?\d+/gi, '.');        // E01, EP01
         name = name.replace(/\.第\s*\d+\s*[集季话]/gi, '.'); // 第1集, 第1季, 第1话
 
@@ -321,8 +322,8 @@ class TaskService {
 
             // ====== 启发式判断视频类型（在 TMDB 搜索前分析资源特征） ======
             let inferredType = null; // 启发式推断的类型，优先级低于用户指定
+            // 1. 根据保存路径中的关键字判断（仅当用户未指定类型时）
             if (!taskDto?.videoType) {
-                // 1. 根据保存路径中的关键字判断
                 const savePath = taskDto?.realFolderName || '';
                 const moviePathKeywords = ['/电影/', '/Movies/', '/Movie/', '/movie/', '/影片/'];
                 const tvPathKeywords = ['/电视剧/', '/TV/', '/Tv/', '/tv/', '/剧集/', '/动漫/', '/番剧/'];
@@ -333,31 +334,30 @@ class TaskService {
                     inferredType = 'tv';
                     logTaskEvent(`[AI重命名] 启发式判断：保存路径含电视剧关键字 -> 推断为电视剧`);
                 }
+            }
 
-                // 2. 根据文件数量判断（单文件更可能是电影）
-                if (!inferredType && files && files.length > 0) {
-                    const mediaFiles = files.filter(f => !f.isFolder);
-                    if (mediaFiles.length === 1) {
-                        inferredType = 'movie';
-                        logTaskEvent(`[AI重命名] 启发式判断：仅1个媒体文件 -> 推断为电影`);
-                    }
+            // 2. 根据文件数量判断（单文件更可能是电影）
+            if (!inferredType && files && files.length > 0) {
+                const mediaFiles = files.filter(f => !f.isFolder);
+                if (mediaFiles.length === 1) {
+                    inferredType = 'movie';
+                    logTaskEvent(`[AI重命名] 启发式判断：仅1个媒体文件 -> 推断为电影`);
                 }
+            }
 
-                // 3. 根据文件名中的季集信息判断（有季集标识则是电视剧）
-                if (!inferredType && files && files.length > 0) {
-                    const hasEpisodePattern = files.some(f =>
-                        /S\d+[-_ ]*E\d+|第\s*\d+\s*[集话]|EP?\d+/i.test(f.name || '')
-                    );
-                    if (hasEpisodePattern) {
-                        inferredType = 'tv';
-                        logTaskEvent(`[AI重命名] 启发式判断：文件名含季集标识 -> 推断为电视剧`);
-                    }
+            // 3. 根据文件名中的季集信息判断（有季集标识则是电视剧）
+            if (!inferredType && files && files.length > 0) {
+                const hasEpisodePattern = files.some(f =>
+                    /S\d+[-_ ]*E\d+|第\s*\d+\s*[集话]|EP?\d+/i.test(f.name || '')
+                );
+                if (hasEpisodePattern) {
+                    inferredType = 'tv';
+                    logTaskEvent(`[AI重命名] 启发式判断：文件名含季集标识 -> 推断为电视剧`);
                 }
+            }
 
-                // 4. 多文件且无季集信息，可能是电影合集，仍优先搜电视剧（安全回退）
-                if (inferredType) {
-                    logTaskEvent(`[AI重命名] 启发式判断最终结果: ${inferredType === 'movie' ? '电影' : '电视剧'}`);
-                }
+            if (inferredType) {
+                logTaskEvent(`[AI重命名] 启发式判断最终结果: ${inferredType === 'movie' ? '电影' : '电视剧'}`);
             }
 
             try {
@@ -385,16 +385,20 @@ class TaskService {
                         logTaskEvent(`[AI重命名] 使用提取的 TMDB ID ${extractedTmdbId} 直接查询详情...`);
                         const tmdbService = new TMDBService();
 
-                        // 根据用户指定的类型查询，未指定时先尝试 TV 再尝试 Movie
+                        // 使用启发式推断结果决定查询顺序，auto-detect 的 videoType 作为回退
                         let detail = null;
-                        if (taskDto?.videoType === 'movie') {
+                        const searchType = inferredType || taskDto?.videoType || 'tv';
+                        if (searchType === 'movie') {
                             detail = await tmdbService.getMovieDetails(extractedTmdbId);
-                            tmdbType = 'movie';
-                        } else if (taskDto?.videoType === 'tv') {
-                            detail = await tmdbService.getTVDetails(extractedTmdbId);
-                            tmdbType = 'tv';
+                            if (detail && detail.title) {
+                                tmdbType = 'movie';
+                            } else {
+                                detail = await tmdbService.getTVDetails(extractedTmdbId);
+                                if (detail && detail.title) {
+                                    tmdbType = 'tv';
+                                }
+                            }
                         } else {
-                            // 未指定类型，优先尝试 TV（因为 CAS 资源多为剧集）
                             detail = await tmdbService.getTVDetails(extractedTmdbId);
                             if (detail && detail.title) {
                                 tmdbType = 'tv';
@@ -937,17 +941,43 @@ class TaskService {
                     const tmdbApiKey = ConfigService.getConfigValue('tmdb.tmdbApiKey');
                     if (tmdbApiKey && !task.videoType) {
                         try {
+                            // 1. 根据保存路径启发式推断
+                            const savePath = task.realFolderName || '';
+                            const movieKeywords = ['/电影/', '/Movies/', '/movie/', '/影片/'];
+                            const tvKeywords = ['/电视剧/', '/TV/', '/tv/', '/剧集/', '/动漫/', '/番剧/',
+                                                '/国产剧/', '/外语剧/', '/更新中/', '/纪录片/'];
+                            let inferredType = null;
+                            if (movieKeywords.some(k => savePath.includes(k))) {
+                                inferredType = 'movie';
+                            } else if (tvKeywords.some(k => savePath.includes(k))) {
+                                inferredType = 'tv';
+                            }
+
+                            // 2. 根据任务名中的季集标识推断（S01E01、Season、第1季等）
+                            if (!inferredType) {
+                                const hasEpisodePattern = /S\d{1,2}[-_ ]*E\d{1,3}|Season\s*\d+|第\s*\d+\s*[季集话]|\d{1,4}x\d{1,3}/i.test(task.resourceName || '');
+                                if (hasEpisodePattern) {
+                                    inferredType = 'tv';
+                                }
+                            }
+
+                            // 3. 按推断结果决定查询顺序
                             const tmdbService = new TMDBService();
-                            const tvDetail = await tmdbService.getTVDetails(extractedTmdbId);
-                            if (tvDetail && tvDetail.title) {
+                            let movieDetail = null, tvDetail = null;
+                            if (inferredType === 'movie') {
+                                movieDetail = await tmdbService.getMovieDetails(extractedTmdbId);
+                                if (!movieDetail?.title) tvDetail = await tmdbService.getTVDetails(extractedTmdbId);
+                            } else {
+                                tvDetail = await tmdbService.getTVDetails(extractedTmdbId);
+                                if (!tvDetail?.title) movieDetail = await tmdbService.getMovieDetails(extractedTmdbId);
+                            }
+
+                            if (movieDetail?.title) {
+                                task.videoType = 'movie';
+                                task.tmdbTitle = movieDetail.title;
+                            } else if (tvDetail?.title) {
                                 task.videoType = 'tv';
                                 task.tmdbTitle = tvDetail.title;
-                            } else {
-                                const movieDetail = await tmdbService.getMovieDetails(extractedTmdbId);
-                                if (movieDetail && movieDetail.title) {
-                                    task.videoType = 'movie';
-                                    task.tmdbTitle = movieDetail.title;
-                                }
                             }
                         } catch (e) {
                             logTaskEvent(`[任务执行] TMDB ID ${extractedTmdbId} 类型检测失败: ${e.message}`);


### PR DESCRIPTION
fix: processTask TMDB 类型检测改为启发式优先，修复电影被误识别为剧集导致重命名错误

processTask 中提取 {tmdb-xxx} 后先查 TV API，ID 在 TV 端有另一节目时
误判为 tv，导致重命名使用剧集模板生成 S01ENaN。

改为两步启发式推断决定 TMDB 查询顺序：
1. 保存路径关键词（/电影/→movie，/国产剧//外语剧//更新中//纪录片/→tv）
2. 任务名季集标识（S01E01、Season、第1季→tv）

首选查不到时自动回退另一种类型。
同时修复了行 210 文件提纯方法
适配Solitary.Gourmet.S11.2012.1080p.Hami.WEB-DL.H.264.AAC-HiveWeb 仅秒传

